### PR TITLE
Disable the SysTick ISR

### DIFF
--- a/Mainboard/Firmware/motherboard_v1/Core/Src/main.c
+++ b/Mainboard/Firmware/motherboard_v1/Core/Src/main.c
@@ -30,6 +30,15 @@ int main(void)
     // Infinite loop (all real work is done in ISRs)
     uint8_t led = 0;
 
+    // Disable the SysTick ISR
+    //
+    // The SysTick ISR causes jitter in the firmware operation,
+    // and since this project does not use the SysTick features,
+    // we do not need it to run during operation!
+    //
+    // Set bit 0 to 0
+    SysTick->CTRL &= 0xFFFFFFFE;
+    
     while (1) {
         drv_led_clear();
         drv_led_on(1 << led);


### PR DESCRIPTION
The default AMDS firmware works fine, but exhibits a rather large jitter in timing---I believe this issue has been present in the AMDS firmware for years. The end result is that, from the AMDC perspective, the AMDS total sampling time has around `1 us` of jitter. This was observed by @annikaolson during testing of the new `Timing Manager` feature in the AMDC FPGA.

I was doing some testing in the lab to try to figure out why and reduce the jitter. There is no reason the AMDS shouldn't behave EXACTLY the same way for each sampling instance.

I found the issue: the AMDS firmware is totally interrupt-driven: the GPIO EXTI ISR for the `SYNC_ADC` signal from the AMDC triggers the ADC sampling etc. However, there is another ISR lurking, the default `SysTick` ISR. In the current firmware, the SysTick ISR is actually higher priority vs. the SYNC_ADC ISR. Therefore, sometimes, it fires during the sampling which causes the large jitter as the MCU handles the SysTick.

Since the AMDS does not use the SysTick feature, we can simply disable the ISR on boot. Right before the `while(1)` loop in the `main.c` file, add this line of code:

```C
// Disable the SysTick ISR
//
// The SysTick ISR causes jitter in the firmware operation,
// and since this project does not use the SysTick features,
// we do not need it to run during operation!
//
// Set bit 0 to 0
SysTick->CTRL &= 0xFFFFFFFE;
``` 

Based on the scope testing, this reduces the jitter to about 70 ns (about 12 clock cycles), which is simply the MCU ISR handling jitter. Now, the AMDC won't see hardly any jitter when sampling from the AMDS. However, this fix only reduces the jitter---there is still around 10us of latency for the total AMDS sampling and data transmission.