### PR TITLE
Add changelog notes for v2.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This document summarizes the changes introduced to the code base for each releas
 
 ## v2.0.0
 
-- Add sampling of new data upon receipt of `SYNC_ADC` interrupt
+- Sample and transmit data upon receipt of `SYNC_ADC` interrupt
 - Remove `SYNC_TX` interrupt
 
 ## v1.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 This document summarizes the changes introduced to the code base for each release.
 
+## v2.0.0
+
+- Add sampling of new data upon receipt of `SYNC_ADC` interrupt
+- Remove `SYNC_TX` interrupt
+
 ## v1.0.0
 
 Initial commit of released code base.


### PR DESCRIPTION
Added changelog notes for v2.0.0 release. **Reviewers,** can you please make sure I have captured the release notes correctly?

Related feature PR: 
- #52

## Upon Merging This PR
Per #51, we will
1. Delete release [v1.3.x](https://github.com/Severson-Group/AMDS/releases/tag/v1.3.x)
2. Create a `v2.0.x` branch off of `develop` and set it to be the default repo branch
3. Create a `v2.0.0` release / tag off of the `v2.0.x` branch.
4. Add requirements information near the top of [AMDS Interface doc](https://docs.amdc.dev/getting-started/user-guide/amds-interface/) of what version of AMDS is required for each release of AMDC.