### PR TITLE
Add changelog notes for v2.0.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This document summarizes the changes introduced to the code base for each release.
 
+## v2.0.1
+
+- Fix and standarize PCB release file packages for all boards
+
 ## v2.0.0
 
 - Sample and transmit data upon receipt of `SYNC_ADC` interrupt


### PR DESCRIPTION
Add changelog notes for v2.0.1 release. In reviewing this, please consider whether any of our v2.0.1 changes merit an additional bullet or further clarification in the changelog. 

You can find a list of issues that are addressed in this release on the [AMDS release planner project board](https://github.com/orgs/Severson-Group/projects/42) under `v2.0.1`. 