### PR TITLE
Optimize DMA routing time for ST MCU

### DIFF
--- a/Mainboard/Firmware/motherboard_v1/Core/Inc/drv_uart.h
+++ b/Mainboard/Firmware/motherboard_v1/Core/Inc/drv_uart.h
@@ -35,24 +35,80 @@ typedef struct {
 extern uart_rx_tracker_t tracker4;
 extern uart_rx_tracker_t tracker5;
 
-#define AMDS_RX_BUF_SIZE 256
+#define AMDS_RX_BUF_SIZE 256 // Must be 256 for uint8_t indexing and wrap-around logic to work correctly
 extern uint8_t UART4_DMA_Pool[AMDS_RX_BUF_SIZE];
 extern uint8_t UART5_DMA_Pool[AMDS_RX_BUF_SIZE];
+
+extern volatile uint8_t uart2_dma_queue[AMDS_RX_BUF_SIZE];
+extern volatile uint8_t uart3_dma_queue[AMDS_RX_BUF_SIZE];
+extern volatile uint8_t uart2_dma_buffer[AMDS_RX_BUF_SIZE];
+extern volatile uint8_t uart3_dma_buffer[AMDS_RX_BUF_SIZE];
+
+// Queue tracking indices
+extern volatile uint16_t u2_q_head;
+extern volatile uint16_t u2_q_tail;
+extern volatile uint16_t u3_q_head;
+extern volatile uint16_t u3_q_tail;
+
+// Declare the global flag so all .c files know it exists
+extern volatile bool is_routing_active;
 
 void process_uart_fifo(uint8_t *pool, uart_rx_tracker_t *track, uint8_t uart_id);
 void dma_queue(uint8_t uart_id, uint8_t *data, uint8_t len);
 
 void process_routing(void);
-void process_routing_old(void);
 
-static inline bool data_ready()
-{
-	uint8_t dma_ptr4 = (uint8_t)(AMDS_RX_BUF_SIZE - __HAL_DMA_GET_COUNTER(huart4.hdmarx));
-	uint8_t dma_ptr5 = (uint8_t)(AMDS_RX_BUF_SIZE - __HAL_DMA_GET_COUNTER(huart5.hdmarx));;
+/**
+ * Thread-safe, non-blocking wrapper for process_routing().
+ * Uses an atomic try-lock to prevent reentrancy without 
+ * stalling the CPU or blinding interrupts for too long.
+ */
+static inline void try_process_routing(void) {
+    // 1. Enter brief critical section (approx. 3 CPU cycles)
+    __disable_irq();
+    
+    // 2. Check if the lock is already claimed
+    if (is_routing_active) {
+        // Someone else is already routing. Safely abort.
+        __enable_irq();
+        return; 
+    }
+    
+    // 3. Claim the lock
+    is_routing_active = true;
+    
+    // 4. Exit critical section BEFORE the heavy lifting
+    __enable_irq(); 
 
-	return ((tracker4.read_index != dma_ptr4) || (tracker5.read_index != dma_ptr5));
+    // 5. Perform the actual routing with interrupts perfectly active
+    process_routing();
+
+    // 6. Release the lock when finished
+    // (This single write is inherently atomic on a 32-bit ARM core, 
+    // so we don't need to disable interrupts just to clear it).
+    is_routing_active = false;
 }
 
+/**
+ * Attempt to instantly reset the routing state machine and flush buffers.
+ * To be called ONLY from the very beginning of EXTI3_IRQHandler.
+ */
+static inline void try_reset_routing_state(void) {
+    // Because we are inside an IRQ, we preempted main(). 
+    // We do NOT need to disable interrupts here to check the flag safely.
+    if (!is_routing_active) {
+        
+        // 1. Reset state machines to gracefully await the next packet
+        tracker4.state = STATE_IDLE;
+        tracker5.state = STATE_IDLE;
+        
+        // 2. Soft-flush the DMA buffers.
+        // We advance our read pointers to exactly where the DMA hardware 
+        // is currently writing. All old, unprocessed bytes are instantly discarded.
+        tracker4.read_index = (uint8_t)(AMDS_RX_BUF_SIZE - __HAL_DMA_GET_COUNTER(huart4.hdmarx));
+        tracker5.read_index = (uint8_t)(AMDS_RX_BUF_SIZE - __HAL_DMA_GET_COUNTER(huart5.hdmarx));
+    }
+}
 
 static inline void drv_uart_putc_fast(USART_TypeDef *uart, uint8_t data)
 {

--- a/Mainboard/Firmware/motherboard_v1/Core/Src/adc.c
+++ b/Mainboard/Firmware/motherboard_v1/Core/Src/adc.c
@@ -154,9 +154,9 @@ static void adc_sample_all_daughtercards(uint16_t *sample_data_out)
 void EXTI3_IRQHandler(void)
 {
 	// alert daisy chained AMDSs to begin converting
+	//reset DMA routing state machine to ensure robust operation in case bytes were dropped
+	try_reset_routing_state();
 	GPIO_TOGGLE_PIN(GPIOD, GPIO_PIN_1);
-    //reset DMA routing state machine to ensure robust operation in case bytes were dropped
-    try_reset_routing_state();
 	// Perform the actual SPI transactions
 	uint16_t new_data[8] = { 0 };
     adc_sample_all_daughtercards(new_data);

--- a/Mainboard/Firmware/motherboard_v1/Core/Src/adc.c
+++ b/Mainboard/Firmware/motherboard_v1/Core/Src/adc.c
@@ -155,6 +155,8 @@ void EXTI3_IRQHandler(void)
 {
 	// alert daisy chained AMDSs to begin converting
 	GPIO_TOGGLE_PIN(GPIOD, GPIO_PIN_1);
+    //reset DMA routing state machine to ensure robust operation in case bytes were dropped
+    try_reset_routing_state();
 	// Perform the actual SPI transactions
 	uint16_t new_data[8] = { 0 };
     adc_sample_all_daughtercards(new_data);
@@ -189,7 +191,8 @@ void EXTI3_IRQHandler(void)
 		}
 	}
 
-	process_routing_old();
+    //Handle any DMA data that has been received from daisy chain
+	try_process_routing(); // This try function is thread safe
 
     // Clear all pending IRQs for ADC conversions at the
     // end of this ISR so that the system realigns the

--- a/Mainboard/Firmware/motherboard_v1/Core/Src/drv_uart.c
+++ b/Mainboard/Firmware/motherboard_v1/Core/Src/drv_uart.c
@@ -25,122 +25,154 @@ uart_rx_tracker_t tracker5 = {0};
 uint8_t UART4_DMA_Pool[AMDS_RX_BUF_SIZE];
 uint8_t UART5_DMA_Pool[AMDS_RX_BUF_SIZE];
 
-uint8_t count4 = 0;
-uint8_t count5 = 0;
+volatile uint8_t uart2_dma_queue[AMDS_RX_BUF_SIZE];
+volatile uint8_t uart3_dma_queue[AMDS_RX_BUF_SIZE];
+volatile uint8_t uart2_dma_buffer[AMDS_RX_BUF_SIZE];
+volatile uint8_t uart3_dma_buffer[AMDS_RX_BUF_SIZE];
 
-static inline void process_single_byte(uint8_t *pool, uart_rx_tracker_t *track, USART_TypeDef *target_uart, uint8_t count) {
-    uint8_t byte = pool[track->read_index];
+volatile uint16_t u2_q_head = 0;
+volatile uint16_t u2_q_tail = 0;
+volatile uint16_t u3_q_head = 0;
+volatile uint16_t u3_q_tail = 0;
 
-    // read_index is 8 bits long so it will already wrap after 256
-    track->read_index++;
+// Global flag to track if routing is actively occurring.
+// Must be volatile so the compiler knows it can change inside an IRQ.
+volatile bool is_routing_active = false;
 
-//    switch (track->state) {
-//        case STATE_IDLE:
-//            if ((byte & 0xF0) == 0x90) {
-//                drv_uart_putc_fast(target_uart, byte + 4);
-//                track->state = STATE_GOT_HEADER;
-//            }
-//            break;
-//
-//        case STATE_GOT_HEADER:
-//            drv_uart_putc_fast(target_uart, byte);
-//            track->state = STATE_GOT_MSB;
-//            break;
-//
-//        case STATE_GOT_MSB:
-//            drv_uart_putc_fast(target_uart, byte);
-//            track->state = STATE_IDLE;
-//            break;
-//    }
-    if (count == 0)
-    	byte += 4;
-
-    drv_uart_putc_fast(target_uart, byte);
-
-}
-
-static inline void process_bytes_parallel(uint8_t len) {
-	for (uint8_t i = 0; i < len; i++) {
-        // Fetch bytes and increment indices (relies on 8-bit wrap around)
-        uint8_t byte4 = UART4_DMA_Pool[tracker4.read_index++];
-        uint8_t byte5 = UART5_DMA_Pool[tracker5.read_index++];
-
-        if ((byte4 & 0xF0) == 0x90) {
-			byte4 += 4;
-		}
-
-        if ((byte5 & 0xF0) == 0x90) {
-			byte5 += 4;
-		}
-
-        // Interleave the hardware writes to minimize blocking
-		drv_uart_putc_fast(USART2, byte4 & 0xFE);
-		drv_uart_putc_fast(USART3, byte5 & 0xFE);
-    }
-}
 
 void process_routing(void) {
-    uint8_t dma_ptr4 = (uint8_t)(AMDS_RX_BUF_SIZE - __HAL_DMA_GET_COUNTER(huart4.hdmarx));
-    uint8_t dma_ptr5 = (uint8_t)(AMDS_RX_BUF_SIZE - __HAL_DMA_GET_COUNTER(huart5.hdmarx));
-    uint8_t pending4;
-    uint8_t pending5;
+    // 1. Load tracking state into local CPU registers for zero-wait-state access
+    uint8_t r4 = tracker4.read_index;
+    uint8_t r5 = tracker5.read_index;
+    uint8_t s4 = tracker4.state;
+    uint8_t s5 = tracker5.state;
 
-    do {
-        // Calculate how many unread bytes exist in each buffer
-        pending4 = (uint8_t)(dma_ptr4 - tracker4.read_index);
-        pending5 = (uint8_t)(dma_ptr5 - tracker5.read_index);
+    // 2. Read DMA hardware pointers ONCE at the start. 
+    // NDTR counts down, so the write head is (SIZE - NDTR).
+    // Casting to uint8_t naturally handles the modulo wrap-around at 256.
+    uint8_t w4 = (uint8_t)(AMDS_RX_BUF_SIZE - __HAL_DMA_GET_COUNTER(huart4.hdmarx));
+    uint8_t w5 = (uint8_t)(AMDS_RX_BUF_SIZE - __HAL_DMA_GET_COUNTER(huart5.hdmarx));
 
-        // Process the overlapping chunk in parallel
-        uint8_t common_len = (pending4 < pending5) ? pending4 : pending5;
-        if (common_len > 0) {
-            process_bytes_parallel(common_len);
+    // 3. Process instantly as long as either buffer has data. No NOP delays!
+    while ((r4 != w4) || (r5 != w5)) {
+        
+        // --- Process ONE byte from UART4 ---
+        if (r4 != w4) {
+            uint8_t b4 = UART4_DMA_Pool[r4++];
+            
+            if (s4 == STATE_IDLE) {
+                if ((b4 & 0xF0) == 0x90) {
+                    drv_uart_putc_fast(USART2, b4 + 4); // Increment ID
+                    //If we have another byte, do the next state (this MCU can send 2 bytes fast)
+                    if (r4 != w4) {
+                        b4 = UART4_DMA_Pool[r4++];
+                        drv_uart_putc_fast(USART2, b4);
+                        s4 = STATE_GOT_MSB;
+                    }
+                    else
+                        s4 = STATE_GOT_HEADER;
+                }
+            } else if (s4 == STATE_GOT_HEADER) {
+                drv_uart_putc_fast(USART2, b4);
+                //If we have another byte, do the next state (this MCU can send 2 bytes fast)
+                if (r4 != w4) { 
+                        b4 = UART4_DMA_Pool[r4++];
+                        drv_uart_putc_fast(USART2, b4);
+                        s4 = STATE_IDLE;
+                    }
+                    else
+                        s4 = STATE_GOT_MSB;
+            } else { // STATE_GOT_MSB
+                drv_uart_putc_fast(USART2, b4);
+                //If we have another byte, do the next state (this MCU can send 2 bytes fast)
+                if (r4 != w4) { 
+                    b4 = UART4_DMA_Pool[r4++];
+                    if ((b4 & 0xF0) == 0x90) {
+                        drv_uart_putc_fast(USART2, b4 + 4); // Increment ID
+                        s4 = STATE_GOT_HEADER;
+                    }
+                    else
+                        s4 = STATE_IDLE;    
+                }
+                else
+                    s4 = STATE_IDLE;
+            }
         }
 
-        while ((tracker4.read_index != dma_ptr4) || (tracker5.read_index != dma_ptr5)) {
-			if (tracker4.read_index != dma_ptr4) {
-				process_single_byte(UART4_DMA_Pool, &tracker4, USART2, count4);
-				count4++;
-				if (count4 > 2)
-					count4 = 0;
-			}
+        // --- Process ONE byte from UART5 ---
+        // By interleaving this right after USART2, we give USART2 hardware 
+        // time to shift bits onto the wire, preventing the 3rd byte from blocking!
+        if (r5 != w5) {
+            uint8_t b5 = UART5_DMA_Pool[r5++];
+            
+            if (s5 == STATE_IDLE) {
+                if ((b5 & 0xF0) == 0x90) {
+                    drv_uart_putc_fast(USART3, b5 + 4); // Increment ID
+                    //If we have another byte, do the next state (this MCU can send 2 bytes fast)
+                    if (r5 != w5) {
+                        b5 = UART5_DMA_Pool[r5++];
+                        drv_uart_putc_fast(USART3, b5);
+                        s5 = STATE_GOT_MSB;
+                    }
+                    else
+                        s5 = STATE_GOT_HEADER;
+                }
+            } else if (s5 == STATE_GOT_HEADER) {
+                drv_uart_putc_fast(USART3, b5);
+                //If we have another byte, do the next state (this MCU can send 2 bytes fast)
+                if (r5 != w5) { 
+                        b5 = UART5_DMA_Pool[r5++];
+                        drv_uart_putc_fast(USART3, b5);
+                        s5 = STATE_IDLE;
+                    }
+                    else
+                        s5 = STATE_GOT_MSB;
+            } else { // STATE_GOT_MSB
+                drv_uart_putc_fast(USART3, b5);
+                //If we have another byte, do the next state (this MCU can send 2 bytes fast)
+                if (r5 != w5) { 
+                    b5 = UART5_DMA_Pool[r5++];
+                    if ((b5 & 0xF0) == 0x90) {
+                        drv_uart_putc_fast(USART3, b5 + 4); // Increment ID
+                        s5 = STATE_GOT_HEADER;
+                    }
+                    else
+                        s5 = STATE_IDLE;    
+                }
+                else
+                    s5 = STATE_IDLE;
+            }
+        }
 
-			if (tracker5.read_index != dma_ptr5) {
-				process_single_byte(UART5_DMA_Pool, &tracker5, USART3, count5);
-				count5++;
-				if (count5 > 2)
-					count5 = 0;
-			}
-		}
+        // 4. Check if we caught up to our cached write pointers.
+        // If so, re-sample the DMA registers to see if new data arrived 
+        // while we were actively processing the previous bytes.
+        if ((r4 == w4) && (r5 == w5)) {
+            w4 = (uint8_t)(AMDS_RX_BUF_SIZE - __HAL_DMA_GET_COUNTER(huart4.hdmarx));
+            w5 = (uint8_t)(AMDS_RX_BUF_SIZE - __HAL_DMA_GET_COUNTER(huart5.hdmarx));
+        }
+    }
 
-        // Check one last time to see if new bytes arrived during the parsing loops
-        dma_ptr4 = (uint8_t)(AMDS_RX_BUF_SIZE - __HAL_DMA_GET_COUNTER(huart4.hdmarx));
-        dma_ptr5 = (uint8_t)(AMDS_RX_BUF_SIZE - __HAL_DMA_GET_COUNTER(huart5.hdmarx));
-
-    } while ((tracker4.read_index != dma_ptr4) || (tracker5.read_index != dma_ptr5));
+    // 5. Store the local CPU register states back to global memory before exiting
+    tracker4.read_index = r4;
+    tracker5.read_index = r5;
+    tracker4.state = s4;
+    tracker5.state = s5;
 }
 
-void process_routing_old(void) {
-    // Get the current write head for both DMA channels
-    uint32_t dma_ptr4 = AMDS_RX_BUF_SIZE - __HAL_DMA_GET_COUNTER(huart4.hdmarx);
-    uint32_t dma_ptr5 = AMDS_RX_BUF_SIZE - __HAL_DMA_GET_COUNTER(huart5.hdmarx);
 
-    // Loop as long as EITHER buffer has unread data
-    do {
-		while ((tracker4.read_index != dma_ptr4) || (tracker5.read_index != dma_ptr5)) {
-			if (tracker4.read_index != dma_ptr4) {
-				process_single_byte(UART4_DMA_Pool, &tracker4, USART2, count4);
-			}
-
-			if (tracker5.read_index != dma_ptr5) {
-				process_single_byte(UART5_DMA_Pool, &tracker5, USART3, count5);
-			}
-		}
-
-		// Check one last time before returning to see if bytes arrived while parsing
-		dma_ptr4 = AMDS_RX_BUF_SIZE - __HAL_DMA_GET_COUNTER(huart4.hdmarx);
-		dma_ptr5 = AMDS_RX_BUF_SIZE - __HAL_DMA_GET_COUNTER(huart5.hdmarx);
-
-	} while ((tracker4.read_index != dma_ptr4) || (tracker5.read_index != dma_ptr5));
+void dma_queue(uint8_t uart_id, uint8_t *data, uint8_t len) {
+    if (uart_id == 2) {
+        for (int i = 0; i < len; i++) {
+            uart2_dma_queue[u2_q_head] = data[i];
+            u2_q_head = (u2_q_head + 1) % AMDS_RX_BUF_SIZE;
+        }
+    } else if (uart_id == 3) {
+        for (int i = 0; i < len; i++) {
+            uart3_dma_queue[u3_q_head] = data[i];
+            u3_q_head = (u3_q_head + 1) % AMDS_RX_BUF_SIZE;
+        }
+    }
 }
 
 void UART4_IRQHandler(void)

--- a/Mainboard/Firmware/motherboard_v1/Core/Src/main.c
+++ b/Mainboard/Firmware/motherboard_v1/Core/Src/main.c
@@ -24,6 +24,10 @@ int main(void)
     drv_uart_init();
     drv_led_init();
 
+    // Tell the UART to constantly route TX requests to the DMA controller
+//    huart2.Instance->CR3 |= USART_CR3_DMAT;
+//    huart3.Instance->CR3 |= USART_CR3_DMAT;
+
     // Initialize the main modules
     adc_init();
 
@@ -41,21 +45,22 @@ int main(void)
 //    SysTick->CTRL &= 0xFFFFFFFE;
     
     while (1) {
-	// Interleave the parsing and routing for both lines simultaneously
-	process_routing_old();
 
-	// 3. Handle LEDs
-	if (HAL_GetTick() - ledDelta >= 250) {
-		ledDelta = HAL_GetTick();
-		drv_led_clear();
-		drv_led_on(1 << led);
-		drv_led_display();
+        // Handle DMA data from UARTs and route to correct destination
+        try_process_routing(); // This try function is thread safe
 
-		if (++led >= DRV_LED_NUM_TOTAL) {
-			led = 0;
-		}
-	}
-}
+        // Handle LEDs
+        if (HAL_GetTick() - ledDelta >= 250) {
+            ledDelta = HAL_GetTick();
+            drv_led_clear();
+            drv_led_on(1 << led);
+            drv_led_display();
+
+            if (++led >= DRV_LED_NUM_TOTAL) {
+                led = 0;
+            }
+        }
+    }
 }
 
 void HAL_MspInit(void)

--- a/Mainboard/Firmware/motherboard_v1/Core/Src/tx.c
+++ b/Mainboard/Firmware/motherboard_v1/Core/Src/tx.c
@@ -8,20 +8,20 @@ volatile bool sync_event_flag = false; // Set this to true in your EXTI ISR
 
 void process_transmissions(void) {
     // Loop as long as there is data in EITHER queue
-//    while ((u2_q_tail != u2_q_head) || (u3_q_tail != u3_q_head)) {
-//
-//        // If UART2 has data, pop one byte and push it straight to the hardware
-//        if (u2_q_tail != u2_q_head) {
-//            drv_uart_putc_fast(USART2, uart2_dma_queue[u2_q_tail]);
-//            u2_q_tail = (u2_q_tail + 1) % AMDS_RX_BUF_SIZE;
-//        }
-//
-//        // If UART3 has data, pop one byte and push it straight to the hardware
-//        if (u3_q_tail != u3_q_head) {
-//            drv_uart_putc_fast(USART3, uart3_dma_queue[u3_q_tail]);
-//            u3_q_tail = (u3_q_tail + 1) % AMDS_RX_BUF_SIZE;
-//        }
-//    }
+    while ((u2_q_tail != u2_q_head) || (u3_q_tail != u3_q_head)) {
+
+        // If UART2 has data, pop one byte and push it straight to the hardware
+        if (u2_q_tail != u2_q_head) {
+            drv_uart_putc_fast(USART2, uart2_dma_queue[u2_q_tail]);
+            u2_q_tail = (u2_q_tail + 1) % AMDS_RX_BUF_SIZE;
+        }
+
+        // If UART3 has data, pop one byte and push it straight to the hardware
+        if (u3_q_tail != u3_q_head) {
+            drv_uart_putc_fast(USART3, uart3_dma_queue[u3_q_tail]);
+            u3_q_tail = (u3_q_tail + 1) % AMDS_RX_BUF_SIZE;
+        }
+    }
 }
 
 


### PR DESCRIPTION
@mohamed-dek1, I have done some work on optimizing the implementation. This is the result of some web searching and Gemini inquiries on how to write efficient code for this MCU. 

## Key Changes

1. Eliminated `process_single_byte()`. Everything is now directly rolled into `process_routing()`
2. Unroll `process_routing()` to transmit up to two bytes per USART at a time when data is available
3. Make `process_routing()` thread safe (for both `main` and the `EXTI3_IRQHandler` by only calling it via `try_process_routing()`
4. Reset the `process_routing()` state machine upon a new `EXTI3_IRQHandler` event via `try_reset_routing_state()` (also thread safe)

## Disclaimer

This PR stomps (overwrites) changes you have made in your last two commits (7e08bf4 and 9d5b3e5). And so I am loading it here as a PR for you instead of directly committing.

I have not compiled the code or tested it, so there may very well be silly mistakes.

## Next steps

I am quite keen on this new approach and would like you to try compiling / testing it out (stop your other approach and try this).

This PR is setup to merge into the branch you are using for #106.

So... **your next steps are:**
1. Check out this code and make sure it compiles. Fix anything that prevents compiling (directly commit and push onto this branch).
2. Merge this PR (into the branch you are using for #106, already setup for this)
3. Test on the AMDS.