### PR TITLE
Optimize USART transmission code to send data fast for both ADCs and Daisy Chain

### DIFF
--- a/Mainboard/Firmware/motherboard_v1/Core/Inc/drv_uart.h
+++ b/Mainboard/Firmware/motherboard_v1/Core/Inc/drv_uart.h
@@ -50,6 +50,17 @@ extern volatile uint16_t u2_q_tail;
 extern volatile uint16_t u3_q_head;
 extern volatile uint16_t u3_q_tail;
 
+// =========================================================================
+// BENCHMARK MODE FLAG for DMA
+// Comment out this line to return to real hardware DMA operation!
+// =========================================================================
+#define BENCHMARK_MODE 
+// =========================================================================
+
+#ifdef BENCHMARK_MODE
+extern volatile uint8_t mock_dma_write_head;
+#endif
+
 // Declare the global flag so all .c files know it exists
 extern volatile bool is_routing_active;
 
@@ -105,8 +116,13 @@ static inline void try_reset_routing_state(void) {
         // 2. Soft-flush the DMA buffers.
         // We advance our read pointers to exactly where the DMA hardware 
         // is currently writing. All old, unprocessed bytes are instantly discarded.
+#ifdef BENCHMARK_MODE
+        tracker4.read_index = mock_dma_write_head;
+        tracker5.read_index = mock_dma_write_head;
+#else
         tracker4.read_index = (uint8_t)(AMDS_RX_BUF_SIZE - __HAL_DMA_GET_COUNTER(huart4.hdmarx));
         tracker5.read_index = (uint8_t)(AMDS_RX_BUF_SIZE - __HAL_DMA_GET_COUNTER(huart5.hdmarx));
+#endif
     }
 }
 

--- a/Mainboard/Firmware/motherboard_v1/Core/Inc/drv_uart.h
+++ b/Mainboard/Firmware/motherboard_v1/Core/Inc/drv_uart.h
@@ -54,7 +54,7 @@ extern volatile uint16_t u3_q_tail;
 // BENCHMARK MODE FLAG for DMA
 // Comment out this line to return to real hardware DMA operation!
 // =========================================================================
-#define BENCHMARK_MODE 
+//#define BENCHMARK_MODE
 // =========================================================================
 
 #ifdef BENCHMARK_MODE

--- a/Mainboard/Firmware/motherboard_v1/Core/Src/adc.c
+++ b/Mainboard/Firmware/motherboard_v1/Core/Src/adc.c
@@ -182,50 +182,77 @@ void EXTI3_IRQHandler(void)
 	uint16_t new_data[8] = { 0 };
     adc_sample_all_daughtercards(new_data);
 
-    // Conditionally Transmit
-	for (int i = 0; i < 4; i++) {
-		uint8_t header = 0x90 | i;
+    // Send the data we sampled out as fast as possible
+    //
+    // =========================================================================
+    // OPTIMIZATION: Zero-Branch Fast Path for Nominal Operation
+    // =========================================================================
+    if (active_sensor_mask == 0xFF) {
+        // Channel 0 & 4
+        drv_uart_putc_fast(USART2, 0x90);
+        drv_uart_putc_fast(USART3, 0x90);
+        drv_uart_putc_fast(USART2, (uint8_t)(new_data[0] >> 8));
+        drv_uart_putc_fast(USART3, (uint8_t)(new_data[4] >> 8));
+        drv_uart_putc_fast(USART2, (uint8_t)new_data[0]);
+        drv_uart_putc_fast(USART3, (uint8_t)new_data[4]);
 
-		// If both channels in current iteration are enabled. We can do a much faster transmission
-		if ((active_sensor_mask & (1 << i)) && (active_sensor_mask & (1 << (i + 4)))) {
-			// Send header
-			drv_uart_putc_fast(USART2, header);
-			drv_uart_putc_fast(USART3, header);
+        // Channel 1 & 5
+        drv_uart_putc_fast(USART2, 0x91);
+        drv_uart_putc_fast(USART3, 0x91);
+        drv_uart_putc_fast(USART2, (uint8_t)(new_data[1] >> 8));
+        drv_uart_putc_fast(USART3, (uint8_t)(new_data[5] >> 8));
+        drv_uart_putc_fast(USART2, (uint8_t)new_data[1]);
+        drv_uart_putc_fast(USART3, (uint8_t)new_data[5]);
 
-			// Send MSB
-			drv_uart_putc_fast(USART2, (uint8_t)(new_data[i] >> 8));
-			drv_uart_putc_fast(USART3, (uint8_t)(new_data[i + 4] >> 8));
+        // Channel 2 & 6
+        drv_uart_putc_fast(USART2, 0x92);
+        drv_uart_putc_fast(USART3, 0x92);
+        drv_uart_putc_fast(USART2, (uint8_t)(new_data[2] >> 8));
+        drv_uart_putc_fast(USART3, (uint8_t)(new_data[6] >> 8));
+        drv_uart_putc_fast(USART2, (uint8_t)new_data[2]);
+        drv_uart_putc_fast(USART3, (uint8_t)new_data[6]);
 
-			// Send LSB
-			drv_uart_putc_fast(USART2, (uint8_t)(new_data[i]));
-			drv_uart_putc_fast(USART3, (uint8_t)(new_data[i + 4]));
-		} else { // otherwise check each channel individually
-			bool u3 = false;
-			bool u2 = false;
-			// Check Channel 0-3 (UART2)
-			if (active_sensor_mask & (1 << i)) {
-				drv_uart_putc_fast(USART2, header);
-				u2 = true;
-				drv_uart_putc_fast(USART2, (uint8_t)(new_data[i] >> 8));
-			}
+        // Channel 3 & 7
+        drv_uart_putc_fast(USART2, 0x93);
+        drv_uart_putc_fast(USART3, 0x93);
+        drv_uart_putc_fast(USART2, (uint8_t)(new_data[3] >> 8));
+        drv_uart_putc_fast(USART3, (uint8_t)(new_data[7] >> 8));
+        drv_uart_putc_fast(USART2, (uint8_t)new_data[3]);
+        drv_uart_putc_fast(USART3, (uint8_t)new_data[7]);
+    } 
+    // =========================================================================
+    // SLOW PATH: Loop for Partial Masks
+    // =========================================================================
+    else { 
+        for (int i = 0; i < 4; i++) {
+            uint8_t header = 0x90 | i;
 
-			// Check Channel 4-7 (UART3)
-			if (active_sensor_mask & (1 << (i + 4))) {
-				drv_uart_putc_fast(USART3, header);
-				u3 = true;
-				drv_uart_putc_fast(USART3, (uint8_t)(new_data[i + 4] >> 8));
-			}
-
-			if (u2) {
-				drv_uart_putc_fast(USART2, (uint8_t)(new_data[i] & 0xFF));
-			}
-
-			// Check Channel 4-7 (UART3)
-			if (u3) {
-				drv_uart_putc_fast(USART3, (uint8_t)(new_data[i + 4] & 0xFF));
-			}
-		}
-	}
+            if ((active_sensor_mask & (1 << i)) && (active_sensor_mask & (1 << (i + 4)))) {
+                drv_uart_putc_fast(USART2, header);
+                drv_uart_putc_fast(USART3, header);
+                drv_uart_putc_fast(USART2, (uint8_t)(new_data[i] >> 8));
+                drv_uart_putc_fast(USART3, (uint8_t)(new_data[i + 4] >> 8));
+                drv_uart_putc_fast(USART2, (uint8_t)(new_data[i]));
+                drv_uart_putc_fast(USART3, (uint8_t)(new_data[i + 4]));
+            } else { 
+                bool u3 = false;
+                bool u2 = false;
+                
+                if (active_sensor_mask & (1 << i)) {
+                    drv_uart_putc_fast(USART2, header);
+                    u2 = true;
+                    drv_uart_putc_fast(USART2, (uint8_t)(new_data[i] >> 8));
+                }
+                if (active_sensor_mask & (1 << (i + 4))) {
+                    drv_uart_putc_fast(USART3, header);
+                    u3 = true;
+                    drv_uart_putc_fast(USART3, (uint8_t)(new_data[i + 4] >> 8));
+                }
+                if (u2) drv_uart_putc_fast(USART2, (uint8_t)(new_data[i] & 0xFF));
+                if (u3) drv_uart_putc_fast(USART3, (uint8_t)(new_data[i + 4] & 0xFF));
+            }
+        }
+    }
 
     //Handle any DMA data that has been received from daisy chain
 	try_process_routing(); // This try function is thread safe

--- a/Mainboard/Firmware/motherboard_v1/Core/Src/adc.c
+++ b/Mainboard/Firmware/motherboard_v1/Core/Src/adc.c
@@ -185,46 +185,26 @@ void EXTI3_IRQHandler(void)
     // Send the data we sampled out as fast as possible
     //
     // =========================================================================
-    // OPTIMIZATION: Zero-Branch Fast Path for Nominal Operation
+    // OPTIMIZATION: "Tight Loop" Fast Path
+    // Tiny code footprint (fits in I-Cache) + Zero bitwise conditional branching
     // =========================================================================
     if (active_sensor_mask == 0xFF) {
-        // Channel 0 & 4
-        drv_uart_putc_fast(USART2, 0x90);
-        drv_uart_putc_fast(USART3, 0x90);
-        drv_uart_putc_fast(USART2, (uint8_t)(new_data[0] >> 8));
-        drv_uart_putc_fast(USART3, (uint8_t)(new_data[4] >> 8));
-        drv_uart_putc_fast(USART2, (uint8_t)new_data[0]);
-        drv_uart_putc_fast(USART3, (uint8_t)new_data[4]);
-
-        // Channel 1 & 5
-        drv_uart_putc_fast(USART2, 0x91);
-        drv_uart_putc_fast(USART3, 0x91);
-        drv_uart_putc_fast(USART2, (uint8_t)(new_data[1] >> 8));
-        drv_uart_putc_fast(USART3, (uint8_t)(new_data[5] >> 8));
-        drv_uart_putc_fast(USART2, (uint8_t)new_data[1]);
-        drv_uart_putc_fast(USART3, (uint8_t)new_data[5]);
-
-        // Channel 2 & 6
-        drv_uart_putc_fast(USART2, 0x92);
-        drv_uart_putc_fast(USART3, 0x92);
-        drv_uart_putc_fast(USART2, (uint8_t)(new_data[2] >> 8));
-        drv_uart_putc_fast(USART3, (uint8_t)(new_data[6] >> 8));
-        drv_uart_putc_fast(USART2, (uint8_t)new_data[2]);
-        drv_uart_putc_fast(USART3, (uint8_t)new_data[6]);
-
-        // Channel 3 & 7
-        drv_uart_putc_fast(USART2, 0x93);
-        drv_uart_putc_fast(USART3, 0x93);
-        drv_uart_putc_fast(USART2, (uint8_t)(new_data[3] >> 8));
-        drv_uart_putc_fast(USART3, (uint8_t)(new_data[7] >> 8));
-        drv_uart_putc_fast(USART2, (uint8_t)new_data[3]);
-        drv_uart_putc_fast(USART3, (uint8_t)new_data[7]);
+        for (uint32_t i = 0; i < 4; i++) {
+            drv_uart_putc_fast(USART2, 0x90 | i);
+            drv_uart_putc_fast(USART3, 0x90 | i);
+            
+            drv_uart_putc_fast(USART2, (uint8_t)(new_data[i] >> 8));
+            drv_uart_putc_fast(USART3, (uint8_t)(new_data[i + 4] >> 8));
+            
+            drv_uart_putc_fast(USART2, (uint8_t)new_data[i]);
+            drv_uart_putc_fast(USART3, (uint8_t)new_data[i + 4]);
+        }
     } 
     // =========================================================================
-    // SLOW PATH: Loop for Partial Masks
+    // SLOW PATH: Safe loop for Partial Masks
     // =========================================================================
-    else { 
-        for (int i = 0; i < 4; i++) {
+    else {
+        for (uint32_t i = 0; i < 4; i++) {
             uint8_t header = 0x90 | i;
 
             if ((active_sensor_mask & (1 << i)) && (active_sensor_mask & (1 << (i + 4)))) {
@@ -248,8 +228,8 @@ void EXTI3_IRQHandler(void)
                     u3 = true;
                     drv_uart_putc_fast(USART3, (uint8_t)(new_data[i + 4] >> 8));
                 }
-                if (u2) drv_uart_putc_fast(USART2, (uint8_t)(new_data[i] & 0xFF));
-                if (u3) drv_uart_putc_fast(USART3, (uint8_t)(new_data[i + 4] & 0xFF));
+                if (u2) drv_uart_putc_fast(USART2, (uint8_t)(new_data[i]));
+                if (u3) drv_uart_putc_fast(USART3, (uint8_t)(new_data[i + 4]));
             }
         }
     }

--- a/Mainboard/Firmware/motherboard_v1/Core/Src/adc.c
+++ b/Mainboard/Firmware/motherboard_v1/Core/Src/adc.c
@@ -157,6 +157,27 @@ void EXTI3_IRQHandler(void)
 	GPIO_TOGGLE_PIN(GPIOD, GPIO_PIN_1);
     //reset DMA routing state machine to ensure robust operation in case bytes were dropped
     try_reset_routing_state();
+
+#ifdef BENCHMARK_MODE
+    // =========================================================================
+    // INJECT MOCK DMA DATA FOR BENCHMARKING
+    // Simulates 8 packets (24 bytes) arriving instantly on the SYNC edge.
+    // =========================================================================
+    uint8_t current_head = mock_dma_write_head;
+    for (int i = 0; i < 24; i++) {
+        uint8_t idx = (uint8_t)(current_head + i); 
+        if (i % 3 == 0) {
+            UART4_DMA_Pool[idx] = 0x90; // Valid Header
+            UART5_DMA_Pool[idx] = 0x90;
+        } else {
+            UART4_DMA_Pool[idx] = 0xAA; // Dummy Payload Data
+            UART5_DMA_Pool[idx] = 0xBB;
+        }
+    }
+    // Instantly advance the mock hardware write head
+    mock_dma_write_head = (uint8_t)(current_head + 24);
+#endif
+
 	// Perform the actual SPI transactions
 	uint16_t new_data[8] = { 0 };
     adc_sample_all_daughtercards(new_data);

--- a/Mainboard/Firmware/motherboard_v1/Core/Src/adc.c
+++ b/Mainboard/Firmware/motherboard_v1/Core/Src/adc.c
@@ -185,30 +185,45 @@ void EXTI3_IRQHandler(void)
     // Conditionally Transmit
 	for (int i = 0; i < 4; i++) {
 		uint8_t header = 0x90 | i;
-		bool u3 = false;
-		bool u2 = false;
 
-		// Check Channel 0-3 (UART2)
-		if (active_sensor_mask & (1 << i)) {
+		// If both channels in current iteration are enabled. We can do a much faster transmission
+		if ((active_sensor_mask & (1 << i)) && (active_sensor_mask & (1 << (i + 4)))) {
+			// Send header
 			drv_uart_putc_fast(USART2, header);
-			u2 = true;
-			drv_uart_putc_fast(USART2, (uint8_t)(new_data[i] >> 8));
-		}
-
-		// Check Channel 4-7 (UART3)
-		if (active_sensor_mask & (1 << (i + 4))) {
 			drv_uart_putc_fast(USART3, header);
-			u3 = true;
+
+			// Send MSB
+			drv_uart_putc_fast(USART2, (uint8_t)(new_data[i] >> 8));
 			drv_uart_putc_fast(USART3, (uint8_t)(new_data[i + 4] >> 8));
-		}
 
-		if (u2) {
-			drv_uart_putc_fast(USART2, (uint8_t)(new_data[i] & 0xFF));
-		}
+			// Send LSB
+			drv_uart_putc_fast(USART2, (uint8_t)(new_data[i]));
+			drv_uart_putc_fast(USART3, (uint8_t)(new_data[i + 4]));
+		} else { // otherwise check each channel individually
+			bool u3 = false;
+			bool u2 = false;
+			// Check Channel 0-3 (UART2)
+			if (active_sensor_mask & (1 << i)) {
+				drv_uart_putc_fast(USART2, header);
+				u2 = true;
+				drv_uart_putc_fast(USART2, (uint8_t)(new_data[i] >> 8));
+			}
 
-		// Check Channel 4-7 (UART3)
-		if (u3) {
-			drv_uart_putc_fast(USART3, (uint8_t)(new_data[i + 4] & 0xFF));
+			// Check Channel 4-7 (UART3)
+			if (active_sensor_mask & (1 << (i + 4))) {
+				drv_uart_putc_fast(USART3, header);
+				u3 = true;
+				drv_uart_putc_fast(USART3, (uint8_t)(new_data[i + 4] >> 8));
+			}
+
+			if (u2) {
+				drv_uart_putc_fast(USART2, (uint8_t)(new_data[i] & 0xFF));
+			}
+
+			// Check Channel 4-7 (UART3)
+			if (u3) {
+				drv_uart_putc_fast(USART3, (uint8_t)(new_data[i + 4] & 0xFF));
+			}
 		}
 	}
 

--- a/Mainboard/Firmware/motherboard_v1/Core/Src/drv_uart.c
+++ b/Mainboard/Firmware/motherboard_v1/Core/Src/drv_uart.c
@@ -41,16 +41,19 @@ volatile bool is_routing_active = false;
 
 
 void process_routing(void) {
-    // 1. Load tracking state into local CPU registers
+    // 1. Load tracking state into local CPU registers for zero-wait-state access
     uint8_t r4 = tracker4.read_index;
     uint8_t r5 = tracker5.read_index;
     uint8_t s4 = tracker4.state;
     uint8_t s5 = tracker5.state;
 
-    // 2. Read DMA hardware pointers ONCE
+    // 2. Read DMA hardware pointers ONCE at the start. 
+    // NDTR counts down, so the write head is (SIZE - NDTR).
+    // Casting to uint8_t naturally handles the modulo wrap-around at 256.
     uint8_t w4 = (uint8_t)(AMDS_RX_BUF_SIZE - __HAL_DMA_GET_COUNTER(huart4.hdmarx));
     uint8_t w5 = (uint8_t)(AMDS_RX_BUF_SIZE - __HAL_DMA_GET_COUNTER(huart5.hdmarx));
 
+    // Process instantly as long as either buffer has data. No NOP delays!
     while ((r4 != w4) || (r5 != w5)) {
         
         // Calculate exactly how many bytes are sitting unread in the DMA buffer.

--- a/Mainboard/Firmware/motherboard_v1/Core/Src/drv_uart.c
+++ b/Mainboard/Firmware/motherboard_v1/Core/Src/drv_uart.c
@@ -39,6 +39,18 @@ volatile uint16_t u3_q_tail = 0;
 // Must be volatile so the compiler knows it can change inside an IRQ.
 volatile bool is_routing_active = false;
 
+#ifdef BENCHMARK_MODE
+    volatile uint8_t mock_dma_write_head = 0;
+    #define GET_W4() mock_dma_write_head
+    #define GET_W5() mock_dma_write_head
+#else
+    // NDTR counts down, so the write head is (SIZE - NDTR).
+    // Casting to uint8_t naturally handles the modulo wrap-around at 256.
+    // AMDS_RX_BUF_SIZE MUST BE 256 FOR THIS MATH TO WORK PROPERLY!
+    #define GET_W4() (uint8_t)(AMDS_RX_BUF_SIZE - __HAL_DMA_GET_COUNTER(huart4.hdmarx))
+    #define GET_W5() (uint8_t)(AMDS_RX_BUF_SIZE - __HAL_DMA_GET_COUNTER(huart5.hdmarx))
+#endif
+
 
 void process_routing(void) {
     // 1. Load tracking state into local CPU registers for zero-wait-state access
@@ -167,8 +179,8 @@ void process_routing(void) {
         // If so, re-sample the DMA registers to see if new data arrived 
         // while we were actively processing the previous bytes.
         if ((r4 == w4) && (r5 == w5)) {
-            w4 = (uint8_t)(AMDS_RX_BUF_SIZE - __HAL_DMA_GET_COUNTER(huart4.hdmarx));
-            w5 = (uint8_t)(AMDS_RX_BUF_SIZE - __HAL_DMA_GET_COUNTER(huart5.hdmarx));
+            w4 = GET_W4();
+            w5 = GET_W5();
         }
     }
 

--- a/Mainboard/Firmware/motherboard_v1/Core/Src/drv_uart.c
+++ b/Mainboard/Firmware/motherboard_v1/Core/Src/drv_uart.c
@@ -67,7 +67,7 @@ void process_routing(void) {
         // =====================================================================
         // If BOTH streams have at least a full 3-byte packet, process them completely
         // interleaved to keep both hardware lines saturated simultaneously.
-        if ((s4 == STATE_IDLE && avail4 >= 3) && (s5 == STATE_IDLE && avail5 >= 3)) {
+        while ((s4 == STATE_IDLE && avail4 >= 3) && (s5 == STATE_IDLE && avail5 >= 3)) {
             uint8_t h4 = UART4_DMA_Pool[r4];
             uint8_t h5 = UART5_DMA_Pool[r5];
             
@@ -86,12 +86,10 @@ void process_routing(void) {
                 
                 r4 += 3;
                 r5 += 3;
-                
-                if ((r4 == w4) && (r5 == w5)) {
-                    w4 = (uint8_t)(AMDS_RX_BUF_SIZE - __HAL_DMA_GET_COUNTER(huart4.hdmarx));
-                    w5 = (uint8_t)(AMDS_RX_BUF_SIZE - __HAL_DMA_GET_COUNTER(huart5.hdmarx));
-                }
-                continue; // Skip the rest of the loop and keep fast-pathing!
+                avail4 -= 3;
+                avail5 -= 3;
+            } else {
+                break; // Misaligned or corrupted header, break to let the slow-path handle it
             }
         }
 
@@ -99,35 +97,31 @@ void process_routing(void) {
         // OPTIMIZATION 2: SINGLE-STREAM FAST PATHS 
         // =====================================================================
         // If one UART receives data slightly faster than the other, process it.
-        if (s4 == STATE_IDLE && avail4 >= 3) {
+        while (s4 == STATE_IDLE && avail4 >= 3) {
             uint8_t h4 = UART4_DMA_Pool[r4];
             if ((h4 & 0xF0) == 0x90) {
                 drv_uart_putc_fast(USART2, h4 + 4);
                 drv_uart_putc_fast(USART2, UART4_DMA_Pool[(uint8_t)(r4 + 1)]);
                 drv_uart_putc_fast(USART2, UART4_DMA_Pool[(uint8_t)(r4 + 2)]);
-                r4 += 3;
                 
-                if ((r4 == w4) && (r5 == w5)) {
-                    w4 = (uint8_t)(AMDS_RX_BUF_SIZE - __HAL_DMA_GET_COUNTER(huart4.hdmarx));
-                    w5 = (uint8_t)(AMDS_RX_BUF_SIZE - __HAL_DMA_GET_COUNTER(huart5.hdmarx));
-                }
-                continue;
+                r4 += 3;
+                avail4 -= 3;
+            } else {
+                break;
             }
         }
 
-        if (s5 == STATE_IDLE && avail5 >= 3) {
+        while (s5 == STATE_IDLE && avail5 >= 3) {
             uint8_t h5 = UART5_DMA_Pool[r5];
             if ((h5 & 0xF0) == 0x90) {
                 drv_uart_putc_fast(USART3, h5 + 4);
                 drv_uart_putc_fast(USART3, UART5_DMA_Pool[(uint8_t)(r5 + 1)]);
                 drv_uart_putc_fast(USART3, UART5_DMA_Pool[(uint8_t)(r5 + 2)]);
-                r5 += 3;
                 
-                if ((r4 == w4) && (r5 == w5)) {
-                    w4 = (uint8_t)(AMDS_RX_BUF_SIZE - __HAL_DMA_GET_COUNTER(huart4.hdmarx));
-                    w5 = (uint8_t)(AMDS_RX_BUF_SIZE - __HAL_DMA_GET_COUNTER(huart5.hdmarx));
-                }
-                continue;
+                r5 += 3;
+                avail5 -= 3;
+            } else {
+                break;
             }
         }
 
@@ -169,6 +163,9 @@ void process_routing(void) {
             }
         }
 
+        // Check if we caught up to our cached write pointers.
+        // If so, re-sample the DMA registers to see if new data arrived 
+        // while we were actively processing the previous bytes.
         if ((r4 == w4) && (r5 == w5)) {
             w4 = (uint8_t)(AMDS_RX_BUF_SIZE - __HAL_DMA_GET_COUNTER(huart4.hdmarx));
             w5 = (uint8_t)(AMDS_RX_BUF_SIZE - __HAL_DMA_GET_COUNTER(huart5.hdmarx));

--- a/Mainboard/Firmware/motherboard_v1/Core/Src/drv_uart.c
+++ b/Mainboard/Firmware/motherboard_v1/Core/Src/drv_uart.c
@@ -62,8 +62,8 @@ void process_routing(void) {
     // 2. Read DMA hardware pointers ONCE at the start. 
     // NDTR counts down, so the write head is (SIZE - NDTR).
     // Casting to uint8_t naturally handles the modulo wrap-around at 256.
-    uint8_t w4 = (uint8_t)(AMDS_RX_BUF_SIZE - __HAL_DMA_GET_COUNTER(huart4.hdmarx));
-    uint8_t w5 = (uint8_t)(AMDS_RX_BUF_SIZE - __HAL_DMA_GET_COUNTER(huart5.hdmarx));
+    uint8_t w4 = GET_W4();
+    uint8_t w5 = GET_W5();
 
     // Process instantly as long as either buffer has data. No NOP delays!
     while ((r4 != w4) || (r5 != w5)) {

--- a/Mainboard/Firmware/motherboard_v1/Core/Src/drv_uart.c
+++ b/Mainboard/Firmware/motherboard_v1/Core/Src/drv_uart.c
@@ -41,119 +41,138 @@ volatile bool is_routing_active = false;
 
 
 void process_routing(void) {
-    // 1. Load tracking state into local CPU registers for zero-wait-state access
+    // 1. Load tracking state into local CPU registers
     uint8_t r4 = tracker4.read_index;
     uint8_t r5 = tracker5.read_index;
     uint8_t s4 = tracker4.state;
     uint8_t s5 = tracker5.state;
 
-    // 2. Read DMA hardware pointers ONCE at the start. 
-    // NDTR counts down, so the write head is (SIZE - NDTR).
-    // Casting to uint8_t naturally handles the modulo wrap-around at 256.
+    // 2. Read DMA hardware pointers ONCE
     uint8_t w4 = (uint8_t)(AMDS_RX_BUF_SIZE - __HAL_DMA_GET_COUNTER(huart4.hdmarx));
     uint8_t w5 = (uint8_t)(AMDS_RX_BUF_SIZE - __HAL_DMA_GET_COUNTER(huart5.hdmarx));
 
-    // 3. Process instantly as long as either buffer has data. No NOP delays!
     while ((r4 != w4) || (r5 != w5)) {
         
-        // --- Process ONE byte from UART4 ---
+        // Calculate exactly how many bytes are sitting unread in the DMA buffer.
+        // Because everything is cast to uint8_t, this math safely handles 
+        // circular buffer wrap-around natively (e.g. w4=2, r4=254 -> avail=4)
+        uint8_t avail4 = (uint8_t)(w4 - r4);
+        uint8_t avail5 = (uint8_t)(w5 - r5);
+
+        // =====================================================================
+        // OPTIMIZATION 1: DUAL-STREAM FAST PATH (Perfect Interleaving)
+        // =====================================================================
+        // If BOTH streams have at least a full 3-byte packet, process them completely
+        // interleaved to keep both hardware lines saturated simultaneously.
+        if ((s4 == STATE_IDLE && avail4 >= 3) && (s5 == STATE_IDLE && avail5 >= 3)) {
+            uint8_t h4 = UART4_DMA_Pool[r4];
+            uint8_t h5 = UART5_DMA_Pool[r5];
+            
+            if (((h4 & 0xF0) == 0x90) && ((h5 & 0xF0) == 0x90)) {
+                // Byte 1: Headers (Incremented)
+                drv_uart_putc_fast(USART2, h4 + 4);
+                drv_uart_putc_fast(USART3, h5 + 4);
+                
+                // Byte 2: MSB
+                drv_uart_putc_fast(USART2, UART4_DMA_Pool[(uint8_t)(r4 + 1)]);
+                drv_uart_putc_fast(USART3, UART5_DMA_Pool[(uint8_t)(r5 + 1)]);
+                
+                // Byte 3: LSB
+                drv_uart_putc_fast(USART2, UART4_DMA_Pool[(uint8_t)(r4 + 2)]);
+                drv_uart_putc_fast(USART3, UART5_DMA_Pool[(uint8_t)(r5 + 2)]);
+                
+                r4 += 3;
+                r5 += 3;
+                
+                if ((r4 == w4) && (r5 == w5)) {
+                    w4 = (uint8_t)(AMDS_RX_BUF_SIZE - __HAL_DMA_GET_COUNTER(huart4.hdmarx));
+                    w5 = (uint8_t)(AMDS_RX_BUF_SIZE - __HAL_DMA_GET_COUNTER(huart5.hdmarx));
+                }
+                continue; // Skip the rest of the loop and keep fast-pathing!
+            }
+        }
+
+        // =====================================================================
+        // OPTIMIZATION 2: SINGLE-STREAM FAST PATHS 
+        // =====================================================================
+        // If one UART receives data slightly faster than the other, process it.
+        if (s4 == STATE_IDLE && avail4 >= 3) {
+            uint8_t h4 = UART4_DMA_Pool[r4];
+            if ((h4 & 0xF0) == 0x90) {
+                drv_uart_putc_fast(USART2, h4 + 4);
+                drv_uart_putc_fast(USART2, UART4_DMA_Pool[(uint8_t)(r4 + 1)]);
+                drv_uart_putc_fast(USART2, UART4_DMA_Pool[(uint8_t)(r4 + 2)]);
+                r4 += 3;
+                
+                if ((r4 == w4) && (r5 == w5)) {
+                    w4 = (uint8_t)(AMDS_RX_BUF_SIZE - __HAL_DMA_GET_COUNTER(huart4.hdmarx));
+                    w5 = (uint8_t)(AMDS_RX_BUF_SIZE - __HAL_DMA_GET_COUNTER(huart5.hdmarx));
+                }
+                continue;
+            }
+        }
+
+        if (s5 == STATE_IDLE && avail5 >= 3) {
+            uint8_t h5 = UART5_DMA_Pool[r5];
+            if ((h5 & 0xF0) == 0x90) {
+                drv_uart_putc_fast(USART3, h5 + 4);
+                drv_uart_putc_fast(USART3, UART5_DMA_Pool[(uint8_t)(r5 + 1)]);
+                drv_uart_putc_fast(USART3, UART5_DMA_Pool[(uint8_t)(r5 + 2)]);
+                r5 += 3;
+                
+                if ((r4 == w4) && (r5 == w5)) {
+                    w4 = (uint8_t)(AMDS_RX_BUF_SIZE - __HAL_DMA_GET_COUNTER(huart4.hdmarx));
+                    w5 = (uint8_t)(AMDS_RX_BUF_SIZE - __HAL_DMA_GET_COUNTER(huart5.hdmarx));
+                }
+                continue;
+            }
+        }
+
+        // =====================================================================
+        // SLOW PATH: Fragmentation / State Recovery
+        // =====================================================================
+        // We only fall down here if a packet is fragmented across a DMA update
+        // boundary or if data is corrupted. We can safely revert to the simple 
+        // 1-byte-at-a-time logic.
         if (r4 != w4) {
             uint8_t b4 = UART4_DMA_Pool[r4++];
-            
             if (s4 == STATE_IDLE) {
                 if ((b4 & 0xF0) == 0x90) {
-                    drv_uart_putc_fast(USART2, b4 + 4); // Increment ID
-                    //If we have another byte, do the next state (this MCU can send 2 bytes fast)
-                    if (r4 != w4) {
-                        b4 = UART4_DMA_Pool[r4++];
-                        drv_uart_putc_fast(USART2, b4);
-                        s4 = STATE_GOT_MSB;
-                    }
-                    else
-                        s4 = STATE_GOT_HEADER;
+                    drv_uart_putc_fast(USART2, b4 + 4);
+                    s4 = STATE_GOT_HEADER;
                 }
             } else if (s4 == STATE_GOT_HEADER) {
                 drv_uart_putc_fast(USART2, b4);
-                //If we have another byte, do the next state (this MCU can send 2 bytes fast)
-                if (r4 != w4) { 
-                        b4 = UART4_DMA_Pool[r4++];
-                        drv_uart_putc_fast(USART2, b4);
-                        s4 = STATE_IDLE;
-                    }
-                    else
-                        s4 = STATE_GOT_MSB;
+                s4 = STATE_GOT_MSB;
             } else { // STATE_GOT_MSB
                 drv_uart_putc_fast(USART2, b4);
-                //If we have another byte, do the next state (this MCU can send 2 bytes fast)
-                if (r4 != w4) { 
-                    b4 = UART4_DMA_Pool[r4++];
-                    if ((b4 & 0xF0) == 0x90) {
-                        drv_uart_putc_fast(USART2, b4 + 4); // Increment ID
-                        s4 = STATE_GOT_HEADER;
-                    }
-                    else
-                        s4 = STATE_IDLE;    
-                }
-                else
-                    s4 = STATE_IDLE;
+                s4 = STATE_IDLE;
             }
         }
 
-        // --- Process ONE byte from UART5 ---
-        // By interleaving this right after USART2, we give USART2 hardware 
-        // time to shift bits onto the wire, preventing the 3rd byte from blocking!
         if (r5 != w5) {
             uint8_t b5 = UART5_DMA_Pool[r5++];
-            
             if (s5 == STATE_IDLE) {
                 if ((b5 & 0xF0) == 0x90) {
-                    drv_uart_putc_fast(USART3, b5 + 4); // Increment ID
-                    //If we have another byte, do the next state (this MCU can send 2 bytes fast)
-                    if (r5 != w5) {
-                        b5 = UART5_DMA_Pool[r5++];
-                        drv_uart_putc_fast(USART3, b5);
-                        s5 = STATE_GOT_MSB;
-                    }
-                    else
-                        s5 = STATE_GOT_HEADER;
+                    drv_uart_putc_fast(USART3, b5 + 4);
+                    s5 = STATE_GOT_HEADER;
                 }
             } else if (s5 == STATE_GOT_HEADER) {
                 drv_uart_putc_fast(USART3, b5);
-                //If we have another byte, do the next state (this MCU can send 2 bytes fast)
-                if (r5 != w5) { 
-                        b5 = UART5_DMA_Pool[r5++];
-                        drv_uart_putc_fast(USART3, b5);
-                        s5 = STATE_IDLE;
-                    }
-                    else
-                        s5 = STATE_GOT_MSB;
+                s5 = STATE_GOT_MSB;
             } else { // STATE_GOT_MSB
                 drv_uart_putc_fast(USART3, b5);
-                //If we have another byte, do the next state (this MCU can send 2 bytes fast)
-                if (r5 != w5) { 
-                    b5 = UART5_DMA_Pool[r5++];
-                    if ((b5 & 0xF0) == 0x90) {
-                        drv_uart_putc_fast(USART3, b5 + 4); // Increment ID
-                        s5 = STATE_GOT_HEADER;
-                    }
-                    else
-                        s5 = STATE_IDLE;    
-                }
-                else
-                    s5 = STATE_IDLE;
+                s5 = STATE_IDLE;
             }
         }
 
-        // 4. Check if we caught up to our cached write pointers.
-        // If so, re-sample the DMA registers to see if new data arrived 
-        // while we were actively processing the previous bytes.
         if ((r4 == w4) && (r5 == w5)) {
             w4 = (uint8_t)(AMDS_RX_BUF_SIZE - __HAL_DMA_GET_COUNTER(huart4.hdmarx));
             w5 = (uint8_t)(AMDS_RX_BUF_SIZE - __HAL_DMA_GET_COUNTER(huart5.hdmarx));
         }
     }
 
-    // 5. Store the local CPU register states back to global memory before exiting
+    // 5. Store states back
     tracker4.read_index = r4;
     tracker5.read_index = r5;
     tracker4.state = s4;


### PR DESCRIPTION
This PR makes several timing improvements:

1. in the external interrupt function, it minimizes the number of branches for the two most likely cases (all 8 cards, or only 2 cards -- full bridge)
2. in the `process_routing` function, it optimizes the conditionals within the state machine to create a fast lane path
3. Adds a benchmark mode to rapidly transmit data. This tests the daisy chain state machine logic with pre-programmed data.

Both of these achieve timing near the bandwidth limits of the USART.

